### PR TITLE
private model uploads until ready to commit, avoiding potential exploit

### DIFF
--- a/finetune/mining.py
+++ b/finetune/mining.py
@@ -28,6 +28,7 @@ from model.storage.model_metadata_store import ModelMetadataStore
 from model.storage.remote_model_store import RemoteModelStore
 import bittensor as bt
 from transformers import PreTrainedModel, PreTrainedTokenizerBase, AutoModelForCausalLM, AutoTokenizer
+from huggingface_hub import update_repo_visibility
 import finetune as ft
 from safetensors.torch import load_model
 
@@ -148,6 +149,7 @@ class Actions:
         # successful.
         while True:
             try:
+                update_repo_visibility(model_id.namespace + "/" + model_id.name, private=False)
                 await self.model_metadata_store.store_model_metadata(
                     self.wallet.hotkey.ss58_address, model_id
                 )
@@ -155,6 +157,7 @@ class Actions:
                 bt.logging.success("Committed model to the chain.")
                 break
             except Exception as e:
+                update_repo_visibility(model_id.namespace + "/" + model_id.name, private=True)
                 bt.logging.error(f"Failed to advertise model on the chain: {e}")
                 bt.logging.error(f"Retrying in {retry_delay_secs} seconds...")
                 time.sleep(retry_delay_secs)

--- a/model/storage/hugging_face/hugging_face_model_store.py
+++ b/model/storage/hugging_face/hugging_face_model_store.py
@@ -28,12 +28,14 @@ class HuggingFaceModelStore(RemoteModelStore):
         model.tokenizer.push_to_hub(
             repo_id=model.id.namespace + "/" + model.id.name,
             token=token,
+            private=True,
         )
 
         commit_info = model.pt_model.push_to_hub(
             repo_id=model.id.namespace + "/" + model.id.name,
             token=token,
             safe_serialization=True,
+            private=True,
         )
 
         model_id_with_commit = ModelId(


### PR DESCRIPTION
Currently, it may be possible to upload someone else's model before they can. 
A bad actor could watch the huggingface accounts of leaderboard participants for the upload of new models, and if they can download the model faster (to compute the hash), they could push the model on chain first. 

This PR changes model uploads to default to private repositories, and then only sets them to public right before committing to the chain, which should prevent this exploit.