### PR TITLE
Implement hotfix for bug in huggingface_hub HfApi

### DIFF
--- a/model/storage/hugging_face/hf_api_hotfix.py
+++ b/model/storage/hugging_face/hf_api_hotfix.py
@@ -1,0 +1,15 @@
+# huggingface_hub contains a bug where SafeTensorsInfo is instantiated with
+# kwargs containing an unexpected key 'sharded', leading to an exception.
+#
+# By replacing the SafeTensorsInfo class with a subclassed version, the
+# 'sharded' key can be removed.
+
+from huggingface_hub import hf_api
+
+class SafeTensorsInfo_fixed(hf_api.SafeTensorsInfo):
+    orig = hf_api.SafeTensorsInfo
+    def __init__(self,**kwargs):
+        kwargs.pop('sharded',None)
+        SafeTensorsInfo_fixed.orig.__init__(self,**kwargs)
+
+hf_api.SafeTensorsInfo = SafeTensorsInfo_fixed

--- a/model/storage/hugging_face/hugging_face_model_store.py
+++ b/model/storage/hugging_face/hugging_face_model_store.py
@@ -9,6 +9,7 @@ from constants import CompetitionParameters, MAX_HUGGING_FACE_BYTES
 from model.storage.remote_model_store import RemoteModelStore
 import constants
 
+from . import hf_api_hotfix
 
 class HuggingFaceModelStore(RemoteModelStore):
     """Hugging Face based implementation for storing and retrieving a model."""


### PR DESCRIPTION
huggingface_hub contains a bug where SafeTensorsInfo is instantiated with kwargs containing an unexpected key 'sharded', leading to an exception.

By replacing the SafeTensorsInfo class with a subclassed version, the 'sharded' key can be removed.